### PR TITLE
Error Fixes for switchMap operator

### DIFF
--- a/src/app/effects/company.effects.ts
+++ b/src/app/effects/company.effects.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
-import { CompanyService } from '../company/company.service';
 import { Actions, Effect, toPayload } from '@ngrx/effects';
+import 'rxjs/add/operator/switchMap';
+
+import { CompanyService } from '../company/company.service';
 import * as companyActions from './../actions/company.actions';
 import { DeleteCompanySuccessAction } from '../actions/company.actions';
 


### PR DESCRIPTION
*Fixed:* 
- `ERROR in C:/ngrx-play-by-play/src/app/effects/company.effects.ts (17,10): Property 'switchMap' does not exist on type 'Actions<Action>'.`
- Changed the order of import statements (core moved above of app dependencies)